### PR TITLE
[fix] 예적금/ 보험 상세보기 wannabeId에 따른 결과가 변경되도록 수정 & 예적금 기본 principal_amount(초기예금액) 세팅 추가

### DIFF
--- a/src/main/java/com/wonnabe/product/controller/ProductDetailController.java
+++ b/src/main/java/com/wonnabe/product/controller/ProductDetailController.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,17 +19,23 @@ public class ProductDetailController {
 
     private final ProductDetailService productDetailService;
 
-    @GetMapping("/savings/{productId}")
-    public ResponseEntity<Object> getSavingProductDetail(@PathVariable String productId) {
-        return JsonResponse.ok("예적금 상품 상세 조회 성공", productDetailService.getSavingProductDetail(productId));
+    @GetMapping("/savings")
+    public ResponseEntity<Object> getSavingProductDetail(
+            @RequestParam("productId") String productId,
+            @RequestParam(value = "wannabeId", required = false) Integer wannabeId,
+            @AuthenticationPrincipal CustomUser customUser) {
+        String userId = (customUser != null) ? customUser.getUser().getUserId() : null;
+        return JsonResponse.ok("예적금 상품 상세 조회 성공", productDetailService.getSavingProductDetail(productId, userId, wannabeId));
     }
 
-    @GetMapping("/insurances/{productId}")
+    @GetMapping("/insurances")
     public ResponseEntity<Object> getInsuranceProductDetail(
-            @PathVariable String productId,
+            @RequestParam("productId") String productId,
+            @RequestParam(value = "wannabeId", required = false) Integer wannabeId,
             @AuthenticationPrincipal CustomUser customUser
     ) {
-        InsuranceProductDetailResponseDTO insuranceProductDetail = productDetailService.getInsuranceProductDetail(productId);
+        String userId = (customUser != null) ? customUser.getUser().getUserId() : null;
+        InsuranceProductDetailResponseDTO insuranceProductDetail = productDetailService.getInsuranceProductDetail(productId, userId, wannabeId);
         return JsonResponse.ok("보험상품 상세 조회 성공", insuranceProductDetail);
     }
 }

--- a/src/main/java/com/wonnabe/product/dto/SavingsApplyRequestDTO.java
+++ b/src/main/java/com/wonnabe/product/dto/SavingsApplyRequestDTO.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class SavingsApplyRequestDTO {
     private Long productId;         // 상품 ID
-    private Long principalAmount;   // 가입 원금 (초기 납입금)
+    private Long principalAmount;   // 목표금액 !!!!!
     private Long monthlyPayment;    // 월 납입액 (적금)
     private Integer joinPeriod;     // 가입 기간 (개월)
 }

--- a/src/main/java/com/wonnabe/product/dto/UserSavingsDetailResponseDto.java
+++ b/src/main/java/com/wonnabe/product/dto/UserSavingsDetailResponseDto.java
@@ -22,10 +22,7 @@ public class UserSavingsDetailResponseDto {
     /** 상품의 고유 ID */
     private String productId;
     private String productName;
-
     private String bankName;
-
-    private Float baseRate; // 기본 금리
 
     /** 상품 유형 ("예금" 또는 "적금") */
     private String productType;
@@ -33,6 +30,8 @@ public class UserSavingsDetailResponseDto {
     private String startDate;
     private String maturityDate;
     private String term;
+
+    private Float baseRate; // 기본 금리
 
     /** 현재까지의 총 잔액 */
     private Long currentAmount;

--- a/src/main/java/com/wonnabe/product/service/ProductDetailService.java
+++ b/src/main/java/com/wonnabe/product/service/ProductDetailService.java
@@ -4,11 +4,11 @@ import com.wonnabe.product.dto.InsuranceProductDetailResponseDTO;
 import com.wonnabe.product.dto.SavingsProductDetailResponseDto;
 
 /*
-* 상세보기!!!
+* 상세보기!!! > wannabeId 추가
 * 1) 예적금: SavingsProductDetailResponseDto
 * 2) 보험: InsuranceProductDetailResponseDto
  */
 public interface ProductDetailService {
-    SavingsProductDetailResponseDto getSavingProductDetail(String productId);
-    InsuranceProductDetailResponseDTO getInsuranceProductDetail(String productId);
+    SavingsProductDetailResponseDto getSavingProductDetail(String productId, String userId, Integer wannabeId);
+    InsuranceProductDetailResponseDTO getInsuranceProductDetail(String productId, String userId, Integer wannabeId);
 }

--- a/src/main/java/com/wonnabe/product/service/UserSavingsService.java
+++ b/src/main/java/com/wonnabe/product/service/UserSavingsService.java
@@ -66,7 +66,8 @@ public class UserSavingsService {
             return (totalExpectedPrincipal == 0) ? 100 : (int) (((double) currentPrincipal / totalExpectedPrincipal) * 100);
         } else {
             // 예금: (현재 총 납입 원금 / 최초 계약 원금) * 100
-            long initialPrincipal = userSavings.getPrincipalAmount();
+            Long initialPrincipalObj = userSavings.getPrincipalAmount();
+            long initialPrincipal = (initialPrincipalObj == null) ? 1000000L : initialPrincipalObj;
             return (initialPrincipal == 0) ? 100 : (int) (((double) currentPrincipal / initialPrincipal) * 100);
         }
     }

--- a/src/test/java/com/wonnabe/product/controller/ProductDetailControllerTest.java
+++ b/src/test/java/com/wonnabe/product/controller/ProductDetailControllerTest.java
@@ -6,14 +6,11 @@ import com.wonnabe.common.config.RootConfig;
 import com.wonnabe.common.config.ServletConfig;
 import com.wonnabe.common.security.account.domain.CustomUser;
 import com.wonnabe.common.security.account.domain.UserVO;
-import com.wonnabe.product.service.ProductDetailService;
-import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -34,157 +31,118 @@ import static org.springframework.test.util.AssertionErrors.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-/**
- * @ExtendWith(SpringExtension.class): JUnit 5에서 Spring 테스트 컨텍스트를 활성화합니다.
- * @WebAppConfiguration: 웹 애플리케이션의 ApplicationContext를 로드합니다. (통합 테스트용)
- * @ContextConfiguration: 로드할 Spring 설정 클래스들을 지정합니다.
- */
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = {
         RootConfig.class,
         ServletConfig.class
 })
-@Log4j2
 class ProductDetailControllerTest {
 
-    // MockMvc는 서블릿 컨테이너를 모의(mock)하여 실제 네트워크 연결 없이 컨트롤러를 테스트할 수 있게 합니다.
     private MockMvc mockMvc;
 
-    // 테스트에 사용할 가짜 사용자 ID
-    private final String userId = "1469a2a3-213d-427e-b29f-f79d58f51190"; // 실제 DB에 존재하는 테스트용 사용자 UUID
+    private final String userId = "1469a2a3-213d-427e-b29f-f79d58f51190";
 
-    @Autowired
-    private ProductDetailService productDetailService; // product 서비스 자동 주입
-
-    // WebApplicationContext는 Spring의 전체 웹 애플리케이션 설정을 담음
     @Autowired
     private WebApplicationContext ctx;
 
-    /**
-     * @BeforeEach: 각 테스트 메서드 실행 전에 호출됩니다.
-     * 여기서는 MockMvc 객체를 초기화하고, 한글 깨짐 방지를 위한 필터를 추가합니다.
-     */
     @BeforeEach
-    public void setup() throws Exception {
-        // Mockito 초기화
-        MockitoAnnotations.openMocks(this);
-
+    public void setup() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
                 .addFilters(new CharacterEncodingFilter("UTF-8", true))
                 .build();
     }
 
-    /**
-     * @AfterEach: 각 테스트 메서드 실행 후에 호출됩니다.
-     * 테스트 간의 독립성을 보장하기 위해 SecurityContext를 초기화합니다.
-     */
     @AfterEach
     void clearSecurityContext() { SecurityContextHolder.clearContext(); }
 
-    /**
-     * 테스트용 가짜 인증(Authentication) 객체를 생성하고 SecurityContextHolder에 설정하는 헬퍼 메서드입니다.
-     * @param userId 인증할 사용자의 ID
-     */
     private void setupAuthentication(String userId) {
         UserVO userVO = new UserVO();
         userVO.setUserId(userId);
-        userVO.setEmail("test@example.com");
-        userVO.setPasswordHash("password"); // 실제 비밀번호는 중요하지 않음
-
+        userVO.setEmail("test@example.com");  // 이메일 설정 추가
+        userVO.setPasswordHash("testpassword");  // 비밀번호 해시 설정 추가
         CustomUser customUser = new CustomUser(userVO);
         Authentication auth = new UsernamePasswordAuthenticationToken(customUser, null, customUser.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
     @Test
-    @DisplayName("[성공] 예적금 상품 상세 정보 조회")
-    void getSavingProductDetail_success() throws Exception {
-        // given: 테스트 사전 조건 설정
-        String productId = "1310"; // DB에 존재하는 예적금 상품 ID
-        setupAuthentication(userId); // "userId" 사용자로 로그인 상태를 시뮬레이션
-
-        // when: MockMvc를 사용하여 API를 호출하고, andExpect로 결과를 기대하는 단계
-        // perform()으로 GET 요청을 보내고, andExpect()로 HTTP 상태 코드가 200(OK)인지 확인합니다.
-        MvcResult result = mockMvc.perform(get("/api/products/savings/{productId}", productId))
-                .andExpect(status().isOk())
-                .andReturn(); // 결과를 MvcResult 객체로 받음
-
-        // then: 응답 결과를 검증하는 단계
-        String jsonResponse = result.getResponse().getContentAsString();
-        log.info("응답 JSON (raw):\n{}", jsonResponse);
-
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> responseMap = null;
-        try {
-            responseMap = mapper.readValue(jsonResponse, new TypeReference<>() {});
-            Object jsonObject = mapper.readValue(jsonResponse, Object.class);
-            String prettyJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
-            log.info("응답 JSON (pretty):\n{}", prettyJson);
-        } catch (Exception e) {
-            log.error("JSON 파싱 중 오류 발생: {}", e.getMessage(), e);
-            fail("JSON 응답 파싱 실패: " + e.getMessage());
-        }
-
-        // 응답의 최상위 "code" 필드가 200인지 확인하여 API 호출이 성공했는지 검증합니다.
-        Integer code = (Integer) responseMap.get("code");
-        assertEquals(200, code, "응답 JSON의 code 필드는 200이어야 합니다.");
-    }
-
-    @Test
-    @DisplayName("[실패] 존재하지 않는 예적금 상품 정보 조회")
-    void getSavingProductDetail_notFound() throws Exception {
+    @DisplayName("[성공] 예적금 상세 조회 (로그인 사용자)")
+    void getSavingProductDetail_loggedIn_success() throws Exception {
         // given
-        String nonExistentProductId = "9999"; // DB에 존재하지 않는 상품 ID
+        String productId = "1310";
         setupAuthentication(userId);
 
         // when & then
-        // 존재하지 않는 상품을 조회하므로 4xx 클라이언트 에러(예: 404 Not Found)를 기대합니다.
-        mockMvc.perform(get("/api/products/savings/{productId}", nonExistentProductId))
-                .andExpect(status().isInternalServerError()); // 500 Internal Server Error를 기대
+        mockMvc.perform(get("/api/products/savings")
+                        .param("productId", productId))
+                .andExpect(status().isOk());
     }
 
     @Test
-    @DisplayName("[성공] 보험 상품 상세 정보 조회")
-    void getInsuranceProductDetail_success() throws Exception {
+    @DisplayName("[성공] 예적금 상세 조회 (로그인 사용자, wannabeId 파라미터 포함)")
+    void getSavingProductDetail_withWannabeId_success() throws Exception {
         // given
-        String productId = "3001"; // DB에 존재하는 보험 상품 ID
-        setupAuthentication(userId);
-
-        // when
-        MvcResult result = mockMvc.perform(get("/api/products/insurances/{productId}", productId))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        // then
-        String jsonResponse = result.getResponse().getContentAsString();
-        log.info("보험 응답 JSON (raw):\n{}", jsonResponse);
-
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> responseMap = null;
-        try {
-            responseMap = mapper.readValue(jsonResponse, new TypeReference<>() {});
-            Object jsonObject = mapper.readValue(jsonResponse, Object.class);
-            String prettyJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
-            log.info("보험 응답 JSON (pretty):\n{}", prettyJson);
-        } catch (Exception e) {
-            log.error("보험 JSON 파싱 중 오류 발생: {}", e.getMessage(), e);
-            fail("보험 JSON 응답 파싱 실패: " + e.getMessage());
-        }
-
-        Integer code = (Integer) responseMap.get("code");
-        assertEquals(200, code, "보험 응답 JSON의 code 필드는 200이어야 합니다.");
-    }
-
-    @Test
-    @DisplayName("[실패] 존재하지 않는 보험 상품 정보 조회")
-    void getInsuranceProductDetail_notFound() throws Exception {
-        // given
-        String nonExistentProductId = "9999"; // DB에 존재하지 않는 보험 상품 ID
+        String productId = "1310";
+        String wannabeId = "3";
         setupAuthentication(userId);
 
         // when & then
-        mockMvc.perform(get("/api/products/insurances/{productId}", nonExistentProductId))
-                .andExpect(status().isInternalServerError()); // 500 Internal Server Error를 기대
+        mockMvc.perform(get("/api/products/savings")
+                        .param("productId", productId)
+                        .param("wannabeId", wannabeId))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[성공] 예적금 상세 조회 (비로그인 사용자)")
+    void getSavingProductDetail_guest_success() throws Exception {
+        // given
+        String productId = "1310";
+
+        // when & then
+        mockMvc.perform(get("/api/products/savings")
+                        .param("productId", productId))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[성공] 보험 상세 조회 (로그인 사용자)")
+    void getInsuranceProductDetail_loggedIn_success() throws Exception {
+        // given
+        String productId = "3001";
+        setupAuthentication(userId);
+
+        // when & then
+        mockMvc.perform(get("/api/products/insurances")
+                        .param("productId", productId))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[성공] 보험 상세 조회 (로그인 사용자, wannabeId 파라미터 포함)")
+    void getInsuranceProductDetail_withWannabeId_success() throws Exception {
+        // given
+        String productId = "3001";
+        String wannabeId = "2";
+        setupAuthentication(userId);
+
+        // when & then
+        mockMvc.perform(get("/api/products/insurances")
+                        .param("productId", productId)
+                        .param("wannabeId", wannabeId))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[성공] 보험 상세 조회 (비로그인 사용자)")
+    void getInsuranceProductDetail_guest_success() throws Exception {
+        // given
+        String productId = "3001";
+
+        // when & then
+        mockMvc.perform(get("/api/products/insurances")
+                        .param("productId", productId))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/wonnabe/product/service/ProductDetailServiceImplTest.java
+++ b/src/test/java/com/wonnabe/product/service/ProductDetailServiceImplTest.java
@@ -2,8 +2,6 @@ package com.wonnabe.product.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wonnabe.common.security.account.domain.CustomUser;
-import com.wonnabe.common.security.account.domain.UserVO;
 import com.wonnabe.product.domain.InsuranceProductVO;
 import com.wonnabe.product.domain.SavingsProductVO;
 import com.wonnabe.product.dto.BasicUserInfoDTO;
@@ -13,16 +11,12 @@ import com.wonnabe.product.mapper.ProductDetailMapper;
 import com.wonnabe.product.mapper.UserInsuranceMapper;
 import com.wonnabe.product.mapper.UserSavingsMapper;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.math.BigDecimal;
 import java.util.Collections;
@@ -31,9 +25,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ProductDetailServiceImplTest {
@@ -57,273 +51,149 @@ class ProductDetailServiceImplTest {
     private UserInsuranceMapper userInsuranceMapper;
 
     @Mock
-    private SecurityContext securityContext;
-
-    @Mock
-    private Authentication authentication;
-
-    @Mock
     private ObjectMapper objectMapper;
 
-    @BeforeEach
-    void setUp() {
-        SecurityContextHolder.setContext(securityContext);
-    }
-
     @SneakyThrows
     @Test
-    @DisplayName("예적금 상품 상세 정보 조회 - 사용자가 찜한 상품일 경우")
-    void getSavingProductDetail_whenProductIsWished() {
+    @DisplayName("예적금 상세 조회 (로그인, 찜 O)")
+    void getSavingProductDetail_loggedIn_wished() {
         // given
         String productId = "1110";
         String userId = "test-user-uuid";
-
-        // CustomUser 객체를 생성하여 반환하도록 모킹
-        UserVO userVO = new UserVO();
-        userVO.setUserId(userId);
-        userVO.setEmail("test@example.com");
-        userVO.setPasswordHash("password");
-        CustomUser customUser = new CustomUser(userVO);
-
-        given(securityContext.getAuthentication()).willReturn(authentication);
-        given(authentication.getPrincipal()).willReturn(customUser);
-
-        SavingsProductVO product = SavingsProductVO.builder()
-                .productId(Long.valueOf(productId))
-                .productName("테스트 적금")
-                .bankName("테스트 은행")
-                .baseRate(3.5f).maxRate(4.0f).prefer("우대조건 테스트")
-                .mtrtInt("만기 후 이율 정보1,만기 후 이율 정보2").maxJoinPeriod(36)
-                .scoreInterestRate(80).scoreInterestType(70).scorePreferentialCondition(90).scoreCancelBenefit(60).scoreMaxAmount(85)
-                .build();
-
-        BasicUserInfoDTO basicUserInfo = BasicUserInfoDTO.builder()
-                .userId(userId)
-                .nowMeId(1)
-                .favoriteProductsByType("[" + productId + ", \"1112\"]")
-                .build();
-
-        given(objectMapper.readValue(anyString(), any(TypeReference.class))).willAnswer(invocation -> {
-            String json = invocation.getArgument(0);
-            if (json.contains(productId)) { // Check if the productId is in the JSON string
-                return List.of(Long.valueOf(productId), 1112L);
-            }
-            return Collections.emptyList(); // Default for other cases, or throw an exception if expected
-        });
-
-        given(productDetailMapper.findSavingProductById(anyString())).willReturn(product);
-        given(productDetailMapper.findBasicUserInfoById(anyString())).willReturn(basicUserInfo);
-
-        double[] weights = {0.3, 0.1, 0.2, 0.3, 0.2};
-        given(savingsRecommendationService.getPersonaWeights()).willReturn(Map.of(1, weights));
-        given(savingsRecommendationService.calculateScore(any(SavingsProductVO.class), any(double[].class))).willReturn(78.5);
-
-        given(userSavingsMapper.findAllByUserId(anyString())).willReturn(Collections.emptyList());
-
-        // when
-        SavingsProductDetailResponseDto result = productService.getSavingProductDetail(productId);
-
-        // then
-        assertNotNull(result, "결과 DTO는 null이 아니어야 합니다.");
-
-        // ProductInfo 검증
-        var productInfo = result.getProductInfo();
-        assertNotNull(productInfo, "ProductInfo는 null이 아니어야 합니다.");
-        assertEquals(productId, productInfo.getProductId(), "상품 ID가 일치해야 합니다.");
-        assertEquals("테스트 적금", productInfo.getProductName(), "상품명이 일치해야 합니다.");
-        assertEquals(78.5, productInfo.getScore(), "Match Score가 일치해야 합니다.");
-        assertTrue(productInfo.isWished(), "찜한 상품이므로 isWished는 true여야 합니다.");
-
-        // ComparisonChart 검증
-        assertTrue(result.getComparisonChart().isEmpty(), "비교 차트 정보는 비어있어야 합니다.");
-
-        // MaturityInfo 검증
-        var maturityInfo = result.getMaturityInfo();
-        assertNotNull(maturityInfo, "만기 정보는 null이 아니어야 합니다.");
-        assertEquals("36개월", maturityInfo.getMaxJoinPeroid(), "최대 가입 기간이 일치해야 합니다.");
-        assertEquals(List.of("만기 후 이율 정보1", "만기 후 이율 정보2"), maturityInfo.getContent(), "만기 후 금리 내용이 일치해야 합니다.");
-    }
-
-    @SneakyThrows
-    @Test
-    @DisplayName("예적금 상품 상세 정보 조회 - 사용자가 찜하지 않은 상품일 경우")
-    void getSavingProductDetail_whenProductIsNotWished() {
-        // given
-        String productId = "1110";
-        String userId = "test-user-uuid";
-
-        // CustomUser 객체를 생성하여 반환하도록 모킹
-        UserVO userVO = new UserVO();
-        userVO.setUserId(userId);
-        userVO.setEmail("test@example.com");
-        userVO.setPasswordHash("password");
-        CustomUser customUser = new CustomUser(userVO);
-
-        given(securityContext.getAuthentication()).willReturn(authentication);
-        given(authentication.getPrincipal()).willReturn(customUser);
+        String favoriteJson = "[" + productId + "]";
 
         SavingsProductVO product = SavingsProductVO.builder().productId(Long.valueOf(productId)).mtrtInt("").build();
+        BasicUserInfoDTO basicUserInfo = BasicUserInfoDTO.builder().userId(userId).nowMeId(1).favoriteProductsByType(favoriteJson).build();
 
-        BasicUserInfoDTO basicUserInfo = BasicUserInfoDTO.builder()
-                .userId(userId)
-                .nowMeId(1)
-                .favoriteProductsByType("[\"1112\", \"1113\"]")
-                .build();
-
-        given(objectMapper.readValue(anyString(), any(TypeReference.class))).willAnswer(invocation -> {
-            String json = invocation.getArgument(0);
-            if (json.contains(productId)) { // Check if the productId is in the JSON string
-                return List.of(Long.valueOf(productId), 1112L);
-            } else {
-                return List.of(1112L, 1113L);
-            }
-        });
-
-        given(productDetailMapper.findSavingProductById(anyString())).willReturn(product);
-        given(productDetailMapper.findBasicUserInfoById(anyString())).willReturn(basicUserInfo);
+        given(productDetailMapper.findSavingProductById(productId)).willReturn(product);
+        given(productDetailMapper.findBasicUserInfoById(userId)).willReturn(basicUserInfo);
+        given(objectMapper.readValue(eq(favoriteJson), any(TypeReference.class))).willReturn(List.of(Long.valueOf(productId)));
         given(savingsRecommendationService.getPersonaWeights()).willReturn(Map.of(1, new double[]{0.2,0.2,0.2,0.2,0.2}));
-        given(savingsRecommendationService.calculateScore(any(), any())).willReturn(0.0);
-        given(userSavingsMapper.findAllByUserId(anyString())).willReturn(Collections.emptyList());
 
         // when
-        SavingsProductDetailResponseDto result = productService.getSavingProductDetail(productId);
+        SavingsProductDetailResponseDto result = productService.getSavingProductDetail(productId, userId, null);
 
         // then
-        assertNotNull(result, "결과 DTO는 null이 아니어야 합니다.");
-        assertFalse(result.getProductInfo().isWished(), "찜하지 않은 상품이므로 isWished는 false여야 합니다.");
+        assertNotNull(result);
+        assertTrue(result.getProductInfo().isWished());
     }
 
     @SneakyThrows
     @Test
-    @DisplayName("보험 상품 상세 정보 조회 - 사용자가 찜한 상품일 경우")
-    void getInsuranceProductDetail_whenProductIsWished() {
+    @DisplayName("예적금 상세 조회 (로그인, wannabeId 사용)")
+    void getSavingProductDetail_loggedIn_withWannabeId() {
         // given
-        String productId = "3001";
+        String productId = "1110";
         String userId = "test-user-uuid";
+        Integer wannabeId = 5;
+        double[] wannabeWeights = {0.5, 0.1, 0.1, 0.1, 0.2};
+        String favoriteJson = "[]";
 
-        UserVO userVO = new UserVO();
-        userVO.setUserId(userId);
-        userVO.setEmail("test@example.com");         // 이메일 추가
-        userVO.setPasswordHash("testPassword123");    // 비밀번호 해시 추가
-        CustomUser customUser = new CustomUser(userVO);
+        SavingsProductVO product = SavingsProductVO.builder().productId(Long.valueOf(productId)).mtrtInt("").build();
+        BasicUserInfoDTO basicUserInfo = BasicUserInfoDTO.builder().userId(userId).nowMeId(1).favoriteProductsByType(favoriteJson).build();
 
-        given(securityContext.getAuthentication()).willReturn(authentication);
-        given(authentication.getPrincipal()).willReturn(customUser);
-
-        InsuranceProductVO product = InsuranceProductVO.builder()
-                .productId(Long.valueOf(productId))
-                .productName("테스트 보험")
-                .providerName("테스트 보험사")
-                .femalePremium(BigDecimal.valueOf(10000))
-                .malePremium(BigDecimal.valueOf(12000))
-                .scorePriceCompetitiveness(80)
-                .scoreCoverageLimit(70)
-                .scoreCoverageScope(90)
-                .scoreDeductibleLevel(60)
-                .scoreRefundScope(75)
-                .coverageType("상해급여")
-                .coverageLimit("연간 5천만원 한도")
-                .coverageDesc("상해로 인한 급여 항목 의료비 보장")
-                .note("기준일: 20250701, 유형: 4세대 실손의료보험, 제공기관: 손해보험협회")
-                .build();
-
-        BasicUserInfoDTO basicUserInfo = BasicUserInfoDTO.builder()
-                .userId(userId)
-                .nowMeId(1)
-                .favoriteProductsByType("[" + productId + ", \"3002\"]")
-                .build();
-
-        given(objectMapper.readValue(anyString(), any(TypeReference.class))).willAnswer(invocation -> {
-            String json = invocation.getArgument(0);
-            if (json.contains(productId)) {
-                return List.of(Long.valueOf(productId), 3002L);
-            }
-            return Collections.emptyList();
-        });
-
-        given(productDetailMapper.findInsuranceProductById(anyString())).willReturn(product);
-        given(productDetailMapper.findBasicUserInfoById(anyString())).willReturn(basicUserInfo);
-
-        double[] weights = {0.3, 0.2, 0.2, 0.1, 0.2}; // 예시 가중치
-        given(insuranceRecommendationService.getPersonaWeights()).willReturn(Map.of(1, weights));
-        given(insuranceRecommendationService.calculateScore(any(InsuranceProductVO.class), any(double[].class))).willReturn(85.0);
-
-        given(userInsuranceMapper.findAllByUserId(anyString())).willReturn(Collections.emptyList());
+        given(productDetailMapper.findSavingProductById(productId)).willReturn(product);
+        given(productDetailMapper.findBasicUserInfoById(userId)).willReturn(basicUserInfo);
+        given(objectMapper.readValue(eq(favoriteJson), any(TypeReference.class))).willReturn(Collections.emptyList());
+        given(savingsRecommendationService.getPersonaWeights()).willReturn(Map.of(wannabeId, wannabeWeights));
+        given(savingsRecommendationService.calculateScore(any(), any())).willReturn(95.0);
 
         // when
-        InsuranceProductDetailResponseDTO result = productService.getInsuranceProductDetail(productId);
+        SavingsProductDetailResponseDto result = productService.getSavingProductDetail(productId, userId, wannabeId);
 
         // then
-        assertNotNull(result, "결과 DTO는 null이 아니어야 합니다.");
+        assertNotNull(result);
+        assertEquals(95.0, result.getProductInfo().getScore());
+        verify(savingsRecommendationService).calculateScore(any(), any(double[].class));
+    }
 
-        var productInfo = result.getProductInfo();
-        assertNotNull(productInfo, "ProductInfo는 null이 아니어야 합니다.");
-        assertEquals(productId, productInfo.getProductId(), "상품 ID가 일치해야 합니다.");
-        assertEquals("테스트 보험", productInfo.getProductName(), "상품명이 일치해야 합니다.");
-        assertEquals("테스트 보험사", productInfo.getProviderName(), "제공사명이 일치해야 합니다.");
-        assertEquals(85, productInfo.getScore(), "Match Score가 일치해야 합니다.");
-        assertEquals("11000", productInfo.getAveragePremium(), "평균 보험료가 일치해야 합니다.");
-        assertTrue(productInfo.isWished(), "찜한 상품이므로 isWished는 true여야 합니다.");
+    @Test
+    @DisplayName("예적금 상세 조회 (비로그인)")
+    void getSavingProductDetail_guest() {
+        // given
+        String productId = "1110";
+        SavingsProductVO product = SavingsProductVO.builder().productId(Long.valueOf(productId)).mtrtInt("").build();
+        given(productDetailMapper.findSavingProductById(productId)).willReturn(product);
 
-        assertTrue(result.getComparisonChart().isEmpty(), "비교 차트 정보는 비어있어야 합니다.");
+        // when
+        SavingsProductDetailResponseDto result = productService.getSavingProductDetail(productId, null, null);
 
-        var maturityInfo = result.getMaturityInfo();
-        assertNotNull(maturityInfo, "만기 정보는 null이 아니어야 합니다.");
-        assertEquals("상해로 인한 급여 항목 의료비 보장", maturityInfo.getCoverageDesc(), "보장 설명이 일치해야 합니다.");
-        assertEquals("기준일: 20250701, 유형: 4세대 실손의료보험, 제공기관: 손해보험협회", maturityInfo.getNote(), "기타 유의사항이 일치해야 합니다.");
+        // then
+        assertNotNull(result);
+        assertFalse(result.getProductInfo().isWished());
+        assertEquals(0.0, result.getProductInfo().getScore());
+        assertTrue(result.getComparisonChart().isEmpty());
     }
 
     @SneakyThrows
     @Test
-    @DisplayName("보험 상품 상세 정보 조회 - 사용자가 찜하지 않은 상품일 경우")
-    void getInsuranceProductDetail_whenProductIsNotWished() {
+    @DisplayName("보험 상세 조회 (로그인, 찜 O)")
+    void getInsuranceProductDetail_loggedIn_wished() {
         // given
         String productId = "3001";
         String userId = "test-user-uuid";
+        String favoriteJson = "[" + productId + "]";
 
-        UserVO userVO = new UserVO();
-        userVO.setUserId(userId);
-        userVO.setEmail("test@example.com");         // 이메일 추가
-        userVO.setPasswordHash("testPassword123");    // 비밀번호 해시 추가
-        CustomUser customUser = new CustomUser(userVO);
+        InsuranceProductVO product = InsuranceProductVO.builder().productId(Long.valueOf(productId)).femalePremium(BigDecimal.ZERO).malePremium(BigDecimal.ZERO).build();
+        BasicUserInfoDTO basicUserInfo = BasicUserInfoDTO.builder().userId(userId).nowMeId(1).favoriteProductsByType(favoriteJson).build();
 
-        given(securityContext.getAuthentication()).willReturn(authentication);
-        given(authentication.getPrincipal()).willReturn(customUser);
-
-        InsuranceProductVO product = InsuranceProductVO.builder()
-                .productId(Long.valueOf(productId))
-                .femalePremium(BigDecimal.valueOf(10000))
-                .malePremium(BigDecimal.valueOf(12000))
-                .build();
-
-        BasicUserInfoDTO basicUserInfo = BasicUserInfoDTO.builder()
-                .userId(userId)
-                .nowMeId(1)
-                .favoriteProductsByType("[\"3002\", \"3003\"]")
-                .build();
-
-        given(objectMapper.readValue(anyString(), any(TypeReference.class))).willAnswer(invocation -> {
-            String json = invocation.getArgument(0);
-            if (json.contains(productId)) {
-                return List.of(Long.valueOf(productId), 3002L);
-            }
-            return List.of(3002L, 3003L);
-        });
-
-        given(productDetailMapper.findInsuranceProductById(anyString())).willReturn(product);
-        given(productDetailMapper.findBasicUserInfoById(anyString())).willReturn(basicUserInfo);
-
-        double[] weights = {0.3, 0.2, 0.2, 0.1, 0.2}; // 예시 가중치
-        given(insuranceRecommendationService.getPersonaWeights()).willReturn(Map.of(1, weights));
-        given(insuranceRecommendationService.calculateScore(any(InsuranceProductVO.class), any(double[].class))).willReturn(0.0);
-
-        given(userInsuranceMapper.findAllByUserId(anyString())).willReturn(Collections.emptyList());
+        given(productDetailMapper.findInsuranceProductById(productId)).willReturn(product);
+        given(productDetailMapper.findBasicUserInfoById(userId)).willReturn(basicUserInfo);
+        given(objectMapper.readValue(eq(favoriteJson), any(TypeReference.class))).willReturn(List.of(Long.valueOf(productId)));
+        given(insuranceRecommendationService.getPersonaWeights()).willReturn(Map.of(1, new double[]{0.2,0.2,0.2,0.2,0.2}));
 
         // when
-        InsuranceProductDetailResponseDTO result = productService.getInsuranceProductDetail(productId);
+        InsuranceProductDetailResponseDTO result = productService.getInsuranceProductDetail(productId, userId, null);
 
         // then
-        assertNotNull(result, "결과 DTO는 null이 아니어야 합니다.");
-        assertFalse(result.getProductInfo().isWished(), "찜하지 않은 상품이므로 isWished는 false여야 합니다.");
+        assertNotNull(result);
+        assertTrue(result.getProductInfo().isWished());
+    }
+
+    @SneakyThrows
+    @Test
+    @DisplayName("보험 상세 조회 (로그인, wannabeId 사용)")
+    void getInsuranceProductDetail_loggedIn_withWannabeId() {
+        // given
+        String productId = "3001";
+        String userId = "test-user-uuid";
+        Integer wannabeId = 3;
+        double[] wannabeWeights = {0.1, 0.4, 0.2, 0.2, 0.1};
+        String favoriteJson = "[]";
+
+        InsuranceProductVO product = InsuranceProductVO.builder().productId(Long.valueOf(productId)).femalePremium(BigDecimal.ZERO).malePremium(BigDecimal.ZERO).build();
+        BasicUserInfoDTO basicUserInfo = BasicUserInfoDTO.builder().userId(userId).nowMeId(1).favoriteProductsByType(favoriteJson).build();
+
+        given(productDetailMapper.findInsuranceProductById(productId)).willReturn(product);
+        given(productDetailMapper.findBasicUserInfoById(userId)).willReturn(basicUserInfo);
+        given(objectMapper.readValue(eq(favoriteJson), any(TypeReference.class))).willReturn(Collections.emptyList());
+        given(insuranceRecommendationService.getPersonaWeights()).willReturn(Map.of(wannabeId, wannabeWeights));
+        given(insuranceRecommendationService.calculateScore(any(), any())).willReturn(88.0);
+
+        // when
+        InsuranceProductDetailResponseDTO result = productService.getInsuranceProductDetail(productId, userId, wannabeId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(88.0, result.getProductInfo().getScore());
+        verify(insuranceRecommendationService).calculateScore(any(), any(double[].class));
+    }
+
+    @Test
+    @DisplayName("보험 상세 조회 (비로그인)")
+    void getInsuranceProductDetail_guest() {
+        // given
+        String productId = "3001";
+        InsuranceProductVO product = InsuranceProductVO.builder().productId(Long.valueOf(productId)).femalePremium(BigDecimal.ZERO).malePremium(BigDecimal.ZERO).build();
+        given(productDetailMapper.findInsuranceProductById(productId)).willReturn(product);
+
+        // when
+        InsuranceProductDetailResponseDTO result = productService.getInsuranceProductDetail(productId, null, null);
+
+        // then
+        assertNotNull(result);
+        assertFalse(result.getProductInfo().isWished());
+        assertEquals(0.0, result.getProductInfo().getScore());
+        assertTrue(result.getComparisonChart().isEmpty());
     }
 }


### PR DESCRIPTION
## 유형
- [ ] 🚀 Feat: 새 기능 추가
- [x] 🚑️ Fix: 버그 수정
- [ ] ♻️ Refactor: 코드 리팩토링
- [ ] 🎨 Style: 코드 스타일 수정 (포맷팅, 세미콜론 등)
- [ ] 💄 Design: UI/스타일 수정 (CSS 등)
- [ ] 📝 Docs: 문서 추가/수정
- [ ] 💡 Comment: 주석 추가/수정
- [ ] 🎉 Init: 프로젝트 초기 설정
- [ ] 🚚 File: 파일/폴더 수정, 이동, 삭제
- [ ] 🐛 Bug: 버그 리포팅 (@FIXME 주석 포함)
- [ ] 🔨 Chore: 기타 (빌드, 패키지 매니저 수정 등)

## 작업 내용
- 예적금/ 보험 상세조회시 WannabId를 가져와서 추천 로직을 확인하게끔 수정
| * 예적금: GET /api/products/savings?productId=1310
| * 보험: GET /api/products/insurances?productId=3001

- url 구조 변경에 따른 테스트 코드 수정

## 스크린샷 (선택)

