### PR TITLE
[fix] #134 change logic to compute monthly_usage from transactions

### DIFF
--- a/src/main/resources/com/wonnabe/product/mapper/CardMapper.xml
+++ b/src/main/resources/com/wonnabe/product/mapper/CardMapper.xml
@@ -87,7 +87,7 @@
         uc.id,
         uc.user_id,
         uc.product_id,
-        uc.monthly_usage,
+        IFNULL(t_latest.amount, 0) AS monthly_usage,
         uc.issue_date,
         uc.expiry_date,
         uc.performance_condition,
@@ -99,7 +99,10 @@
         FROM user_card uc
         JOIN card_product cp ON uc.product_id = cp.product_id
         CROSS JOIN months m
+        CROSS JOIN (SELECT MAX(ym) AS latest_ym FROM months) lm
         LEFT JOIN txn t ON t.uc_id = uc.id AND t.ym = m.ym
+        LEFT JOIN txn t_latest
+        ON t_latest.uc_id = uc.id AND t_latest.ym = lm.latest_ym
         WHERE uc.user_id = #{userId}
         AND uc.product_id = #{productId}
         ORDER BY m.ym ASC


### PR DESCRIPTION
## 유형
- [ ] 🚀 Feat: 새 기능 추가
- [X] 🚑️ Fix: 버그 수정
- [ ] ♻️ Refactor: 코드 리팩토링
- [ ] 🎨 Style: 코드 스타일 수정 (포맷팅, 세미콜론 등)
- [ ] 💄 Design: UI/스타일 수정 (CSS 등)
- [ ] 📝 Docs: 문서 추가/수정
- [ ] 💡 Comment: 주석 추가/수정
- [ ] 🎉 Init: 프로젝트 초기 설정
- [ ] 🚚 File: 파일/폴더 수정, 이동, 삭제
- [ ] 🐛 Bug: 버그 리포팅 (@FIXME 주석 포함)
- [ ] 🔨 Chore: 기타 (빌드, 패키지 매니저 수정 등)

## 작업 내용
- 카드 거래내역이 추가될 때 자동으로 유저 카드의 monthly_usage 컬럼에 숫자가 더해지는 로직이 없음.
- 수동으로 계산하도록 매퍼의 로직을 변경


## 스크린샷 (선택)

